### PR TITLE
Display metric values

### DIFF
--- a/lib/zones.js
+++ b/lib/zones.js
@@ -276,7 +276,9 @@ function selectZone(no) {
 				"univ",
 				"stu_colleg",
 				"stu_school",
-				"taz_area"
+				"taz_area",
+                "pct_qtrmi_transit",
+                "emp_1mi"
 			],
 		    "datfields": {
 		        "fields": ["otraffic_car", "dtraffic_car"],
@@ -315,6 +317,8 @@ var popdensityDIV = $('#dat-zone-popdensity');
 var householdsDIV = $('#dat-zone-households');
 var empresDIV = $('#dat-zone-empres');
 var employmentDIV = $('#dat-zone-employment');
+var transitaccDIV = $('#dat-zone-transitaccess');
+var nearbyempDIV = $('#dat-zone-nearbyemp');
 var k12DIV = $('#dat-zone-k_12');
 var univDIV = $('#dat-zone-univ');
 var stu_collegeDIV = $('#dat-zone-stu_college');
@@ -341,6 +345,8 @@ function populateZoneProfile(zone) {
 	univDIV.html(localHundredsFormat(attData.univ));
 	stu_collegeDIV.html(localHundredsFormat(attData.stu_colleg));
 	stu_schoolDIV.html(localHundredsFormat(attData.stu_school));
+    transitaccDIV.html((attData.pct_qtrmi_transit * 100).toFixed(1) + '%');
+    nearbyempDIV.html(localHundredsFormat(attData.emp_1mi));
 
 	renderEmploymentViz("#employment-graph", attData)
 }


### PR DESCRIPTION
Transit access zone coverage (pct) - 1/4 mi buffer around stops 
Nearby employment - 1 mi buffer sum of employment

Now with actual numbers instead of `0`